### PR TITLE
Fix missing content of posts where comments are disabled by author

### DIFF
--- a/app/views/includes/body.html.erb
+++ b/app/views/includes/body.html.erb
@@ -2,4 +2,5 @@
   class="ljsave"
   style="width: 100%; height: 56px; frameborder: 0; border: 0"
   src="/user/<%= username %>/<%= post_id %>/nav"
-  />
+  >
+</iframe>


### PR DESCRIPTION
### Описание проблемы
Не отображается контент постов с комментариями, отключенными автором.
Пример: https://ljsave.com/user/galkovsky/261673.
![image](https://github.com/mgz/ljsave.com/assets/8080458/4ed12d69-bb58-4b31-9290-2f7e57952cd0)

### Причина
Элемент `iframe` панели навигации не закрыт, поэтому содержание поста считается частью фрейма и не отображается.
[Подробнее о проблеме](https://stackoverflow.com/questions/27545757/why-is-a-self-closing-iframe-tag-preventing-further-dom-elements-to-be-displayed).

Примечание: посты, где комментарии включены, отображаются корректно потому, что имеют элемент
`<iframe class="b-watering-commentator" name="commentator" width="0" height="0" frameborder="0"></iframe>`,
чей закрывающий тег применяется к элементу навигации.

### Решение
Добавить закрывающий тег `</iframe>` в панель навигации.